### PR TITLE
Fix slow removing of ~100 old selectbox options.

### DIFF
--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -653,7 +653,7 @@ var UnoChoice = UnoChoice || (function($) {
             }
             var tagName = filteredElement.tagName;
             if (tagName == 'SELECT') { // handle SELECT's
-               jQuery(filteredElement).children().remove();
+               jQuery(filteredElement).children().detach().remove();
                for (var i = 0; i < newOptions.length ; ++i) {
                    var opt = document.createElement('option');
                    opt.value = newOptions[i].value;


### PR DESCRIPTION
When there are a lot of filtered items (>100) the update of new filter string happens very slowly (~50s).

It happens because jQuery().children().remove() is very slow. Detachment of children helps a lot.
